### PR TITLE
plain mov file support: new  boxes: add support for ctts and stss atom (find PTS offsets and sync frames)

### DIFF
--- a/src/inspectors/mp4.js
+++ b/src/inspectors/mp4.js
@@ -499,6 +499,24 @@ const parse = {
     }
     return result;
   },
+  stss: function (data) {
+    var
+      view = new DataView(data.buffer, data.byteOffset, data.byteLength),
+      result = {
+        version: data[0],
+        flags: new Uint8Array(data.subarray(1, 4)),
+        syncSamples: []
+      },
+      entryCount = view.getUint32(4),
+      i;
+
+    for (i = 8; entryCount; i += 4, entryCount--) {
+      result.syncSamples.push({
+        sampleNumber: view.getUint32(i)
+      });
+    }
+    return result;
+  },
   styp: function (data) {
     return parse.ftyp(data);
   },

--- a/src/inspectors/mp4.js
+++ b/src/inspectors/mp4.js
@@ -480,6 +480,25 @@ const parse = {
     }
     return result;
   },
+  ctts: function (data) {
+    var
+      view = new DataView(data.buffer, data.byteOffset, data.byteLength),
+      result = {
+        version: data[0],
+        flags: new Uint8Array(data.subarray(1, 4)),
+        compositionTimeOffsetToSamples: []
+      },
+      entryCount = view.getUint32(4),
+      i;
+
+    for (i = 8; entryCount; i += 8, entryCount--) {
+      result.compositionTimeOffsetToSamples.push({
+        sampleCount: view.getUint32(i),
+        sampleOffset: view.getUint32(i + 4)
+      });
+    }
+    return result;
+  },
   styp: function (data) {
     return parse.ftyp(data);
   },


### PR DESCRIPTION
composition timestamp offset is needed for plain mp4 video tracks.